### PR TITLE
Correct handle interactive and login shells.

### DIFF
--- a/bash_profile.sh
+++ b/bash_profile.sh
@@ -1,6 +1,12 @@
 # load shared shell configuration
 source ~/.shprofile
 
+# run bashrc if this is a login, interactive shell
+if [ "$0" = "-bash" ] && echo "$-" | grep -q "i"
+then
+  source ~/.bashrc
+fi
+
 # Set HOST for ZSH compatibility
 export HOST=$HOSTNAME
 

--- a/bashrc.sh
+++ b/bashrc.sh
@@ -1,8 +1,10 @@
-# load shared shell configuration
-if [ "$(uname -s)" = "Darwin" ] || grep -q "Microsoft" /proc/version 2>/dev/null
+# run bash_profile if this is not a login shell
+if [ "$0" != "-bash" ]
 then
   source ~/.bash_profile
 fi
+
+# load shared shell configuration
 source ~/.shrc
 
 # History

--- a/zshrc.sh
+++ b/zshrc.sh
@@ -1,5 +1,10 @@
+# run bash_profile if this is not a login shell
+if [ "$0" != "-zsh" ]
+then
+  source ~/.zprofile
+fi
+
 # load shared shell configuration
-source ~/.zprofile
 source ~/.shrc
 
 # History file


### PR DESCRIPTION
Rather than assuming `bashrc`, `bash_profile` or `zprofile` are loaded or not based on platform correctly check whether a shell is a login and/or interactive shell and load files accordingly.

CC @AlJohri for thoughts and review.

Need to do some additional testing on Linux and Ubuntu on Windows.

Fixes #4.