### PR TITLE
Improve GitHub Actions configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+      time: "07:15"
+      timezone: "Europe/London"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
           - macos-latest
     steps:
     - name: Set up Git repository
-      uses: actions/checkout@main
+      uses: actions/checkout@v4
 
     - name: Validate syntax
       run: bash -n *.sh


### PR DESCRIPTION
- Get Dependabot to check for GitHub Actions updates
- Switch GitHub Actions to use tags where possible