### PR TITLE
git-commit-each: expand shard handling

### DIFF
--- a/bin/git-commit-each
+++ b/bin/git-commit-each
@@ -6,7 +6,8 @@ for FILENAME in $(git ls-files --modified --others); do
   MESSAGE="$(echo "$FILENAME" | sed -e 's|^Library/Homebrew/||' \
     -e 's|^Formula/||' \
     -e 's|^Casks/||' \
-    -e 's|^[a-z]/||' \
+    -e 's|^[0-9a-z]/||' \
+    -e 's|^font/\(font-[0-9a-z]/\)\{0,1\}||' \
     -e 's|^lib/||' \
     -e 's/\.rb//' \
     -e 's/$/: /')"


### PR DESCRIPTION
Besides a-z shard directories, homebrew/cask also has numeric ones like `0`, `1`, etc., as well as multi-level `font` directories like `font/font-0`, `font/font-a`, etc. The existing patterns in `git-commit-each` don't handle these directories, so I recently encountered commit messages like `8/8bitdo-ultimate-software: update url, livecheck` and `font/font-h/font-hermit: update homepage` when using this script.

This updates `git-commit-each` to handle these directories as well. I've set up the font pattern so it will handle the existing `font/font-a` structure but would also handle files in `font/` itself. That said, it appears that `sed` on macOS can't handle optional groups like `(something)?` without enabling support for extended regular expressions (`-E`), so I've used `{0,1}` to achieve the same goal.